### PR TITLE
Skips outfile with error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ipynb filter=nbstripout
+*.ipynb diff=ipynb

--- a/notebooks/runBatch.py
+++ b/notebooks/runBatch.py
@@ -6,6 +6,7 @@ lawnPath = "/opt/data/Lawns/"
 dataFolder = "/home/nzjacic/Desktop/Harddrive/10x_GRU101_nolawn/No_smell/Test/"
 batchFolder = "/home/nzjacic/Desktop/Harddrive/10x_GRU101_nolawn/No_smell/Test/"
 
+templateNotebook = '/home/nzjacic/Desktop/BatchRunTemplate-NZ.ipynb'
 # create a dictionary of parameters
 for subfolder in [f.path for f in os.scandir(dataFolder) if f.is_dir()]:
     movie = subfolder.split('/')[-1]
@@ -20,7 +21,7 @@ for subfolder in [f.path for f in os.scandir(dataFolder) if f.is_dir()]:
         print('Analyzing {}. Output can be watched live in'.format(movie), os.path.join(batchFolder, 'out_{}.ipynb'.format(movie)))
         try:
             pm.execute_notebook(
-               '/home/nzjacic/Desktop/BatchRunTemplate-NZ.ipynb',
+               templateNotebook,
                os.path.join(batchFolder, 'out_{movie}.ipynb'),
                parameters=pars
            )


### PR DESCRIPTION
Previously the script would stop if an error was reached in an outfile - patch makes it so that if an error comes up in a notebook, this notebook is skipped and the next outfile in the list is initialized.